### PR TITLE
Feature added: send related attachments

### DIFF
--- a/albo.py
+++ b/albo.py
@@ -2,6 +2,7 @@ import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urlencode, quote_plus
 from typing import List
+import json
 
 TOKEN = ""
 CHATID = 123456
@@ -14,10 +15,41 @@ def escape_char (text: str, char_to_escape: List[str] = ['_', '*', '[', '`']) ->
 def send_telegram_message(text: str) -> None:
     params = {
         'chat_id': CHATID,
-        'text': text
+        'text': text,
+        'parse_mode': 'markdown'
     }
-    URL = "https://api.telegram.org/bot" + TOKEN + "/sendMessage?&parse_mode=markdown&" + urlencode(params, quote_via=quote_plus)
+    URL = "https://api.telegram.org/bot" + TOKEN + "/sendMessage?&" + urlencode(params, quote_via=quote_plus)
     r = requests.get(url = URL)
+
+def send_single_telegram_attachment(pdf_link: str) -> None:
+    params = {
+        'chat_id': CHATID,
+        'document': pdf_link,
+        'disable_notification': True
+    }
+    URL = "https://api.telegram.org/bot" + TOKEN + "/sendDocument?&" + urlencode(params, quote_via=quote_plus)
+    r = requests.get(url = URL)
+
+def send_multiple_telegram_attachments(pdf_links: List[str]) -> None:
+    params = {
+        'chat_id': CHATID,
+        'disable_notification': True,
+        'media': json.dumps([
+          { 
+            "type": "document",
+            "media": pdf_link
+          }
+        for pdf_link in pdf_links]),
+
+    }
+    URL = "https://api.telegram.org/bot" + TOKEN + "/sendMediaGroup?&" + urlencode(params, quote_via=quote_plus)
+    r = requests.get(url = URL)
+
+def send_telegram_attachments(pdf_links: List[str]) -> None:
+  if len(pdf_links) == 1:
+    send_single_telegram_attachment(pdf_links[0])
+  else:
+    send_multiple_telegram_attachments(pdf_links)
 
 with open("last_id.txt", "r") as f:
     last_id = int(f.read())
@@ -47,6 +79,8 @@ for id in range (last_id + 1, new_id + 1):
       message += "\n"
     message += "*" + header + "*: " + escape_char(row[i].span.string) + "\n"
   send_telegram_message(message)
+  attachments = ["http://albo.unict.it/" + list_item['href'] for list_item in tr.find_all('a')]
+  send_telegram_attachments(attachments)
   print(message)
 
 with open("last_id.txt", "w+") as f:

--- a/albo.py
+++ b/albo.py
@@ -41,10 +41,7 @@ def send_multiple_telegram_attachments(pdf_links: List[str]) -> None:
     requests.get(url = URL)
 
 def send_telegram_attachments(pdf_links: List[str]) -> None:
-  if len(pdf_links) == 1:
-    send_single_telegram_attachment(pdf_links[0])
-  else:
-    send_multiple_telegram_attachments(pdf_links)
+  send_single_telegram_attachment(pdf_links[0]) if len(pdf_links) == 1 else send_multiple_telegram_attachments(pdf_links)
 
 with open("last_id.txt", "r") as f:
     last_id = int(f.read())

--- a/albo.py
+++ b/albo.py
@@ -19,7 +19,7 @@ def send_telegram_message(text: str) -> None:
         'parse_mode': 'markdown'
     }
     URL = "https://api.telegram.org/bot" + TOKEN + "/sendMessage?&" + urlencode(params, quote_via=quote_plus)
-    r = requests.get(url = URL)
+    requests.get(url = URL)
 
 def send_single_telegram_attachment(pdf_link: str) -> None:
     params = {
@@ -28,22 +28,17 @@ def send_single_telegram_attachment(pdf_link: str) -> None:
         'disable_notification': True
     }
     URL = "https://api.telegram.org/bot" + TOKEN + "/sendDocument?&" + urlencode(params, quote_via=quote_plus)
-    r = requests.get(url = URL)
+    requests.get(url = URL)
 
 def send_multiple_telegram_attachments(pdf_links: List[str]) -> None:
+    input_media_documents = [ {   "type": "document",  "media": pdf_link   }  for pdf_link in pdf_links]
     params = {
         'chat_id': CHATID,
         'disable_notification': True,
-        'media': json.dumps([
-          { 
-            "type": "document",
-            "media": pdf_link
-          }
-        for pdf_link in pdf_links]),
-
+        'media': json.dumps(input_media_documents),
     }
     URL = "https://api.telegram.org/bot" + TOKEN + "/sendMediaGroup?&" + urlencode(params, quote_via=quote_plus)
-    r = requests.get(url = URL)
+    requests.get(url = URL)
 
 def send_telegram_attachments(pdf_links: List[str]) -> None:
   if len(pdf_links) == 1:
@@ -81,7 +76,7 @@ for id in range (last_id + 1, new_id + 1):
   send_telegram_message(message)
   attachments = ["http://albo.unict.it/" + list_item['href'] for list_item in tr.find_all('a')]
   send_telegram_attachments(attachments)
-  print(message)
+  #print(message)
 
 with open("last_id.txt", "w+") as f:
     f.write(str(new_id))

--- a/albo.py
+++ b/albo.py
@@ -41,7 +41,10 @@ def send_multiple_telegram_attachments(pdf_links: List[str]) -> None:
     requests.get(url = URL)
 
 def send_telegram_attachments(pdf_links: List[str]) -> None:
-  send_single_telegram_attachment(pdf_links[0]) if len(pdf_links) == 1 else send_multiple_telegram_attachments(pdf_links)
+    if len(pdf_links) == 1:
+      send_single_telegram_attachment(pdf_links[0])
+    else:
+      send_multiple_telegram_attachments(pdf_links)
 
 with open("last_id.txt", "r") as f:
     last_id = int(f.read())


### PR DESCRIPTION
Added the possibility to send all the attachments linked to each announcement.
I have provided two different methods to send attachments and a small dispatcher. The first one is used to send a single document, the other is used when more than two documents need to be attached; this way if there are lot of documents to be attached they will all be grouped in a single message.
closes #1 
As a side note I also moved the parse_mode option outside the url and inside the dict